### PR TITLE
fix typo in is_initialize

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -162,7 +162,7 @@ impl Request {
         self.method == "shutdown"
     }
     pub(crate) fn is_initialize(&self) -> bool {
-        self.method == "initialized"
+        self.method == "initialize"
     }
 }
 


### PR DESCRIPTION
VScode just direclty returns `expected initialize request` despite receiving and showing one.
Probably a typo/copy paste from `is_initialized` below.