### PR TITLE
Null params

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl Connection {
             }
         };
 
-        Ok((req.id, req.params))
+        Ok((req.id, req.params.unwrap_or_default()))
     }
 
     /// Finishes the initialization process by sending an `InitializeResult` to the client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl Connection {
             }
         };
 
-        Ok((req.id, req.params.unwrap_or_default()))
+        Ok((req.id, req.params))
     }
 
     /// Finishes the initialization process by sending an `InitializeResult` to the client

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -157,9 +157,10 @@ impl Request {
     }
     pub fn extract<P: DeserializeOwned>(self, method: &str) -> Result<(RequestId, P), Request> {
         if self.method == method {
-            let params = serde_json::from_value(self.params.unwrap_or_default()).unwrap_or_else(|err| {
-                panic!("Invalid request\nMethod: {}\n error: {}", method, err)
-            });
+            let params =
+                serde_json::from_value(self.params.unwrap_or_default()).unwrap_or_else(|err| {
+                    panic!("Invalid request\nMethod: {}\n error: {}", method, err)
+                });
             Ok((self.id, params))
         } else {
             Err(self)
@@ -180,9 +181,10 @@ impl Notification {
     }
     pub fn extract<P: DeserializeOwned>(self, method: &str) -> Result<P, Notification> {
         if self.method == method {
-            let params = serde_json::from_value(self.params.unwrap_or_default()).unwrap_or_else(|err| {
-                panic!("Invalid notification\nMethod: {}\n error: {}", method, err)
-            });
+            let params =
+                serde_json::from_value(self.params.unwrap_or_default()).unwrap_or_else(|err| {
+                    panic!("Invalid notification\nMethod: {}\n error: {}", method, err)
+                });
             Ok(params)
         } else {
             Err(self)
@@ -243,7 +245,6 @@ fn write_msg_text(out: &mut impl Write, msg: &str) -> io::Result<()> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::Message;
@@ -253,7 +254,9 @@ mod tests {
         let text = "{\"jsonrpc\": \"2.0\",\"id\": 3,\"method\": \"shutdown\", \"params\": null }";
         let msg: Message = serde_json::from_str(&text).unwrap();
 
-        assert!( matches!(msg, Message::Request(req) if req.id == 3.into() && req.method == "shutdown") );
+        assert!(
+            matches!(msg, Message::Request(req) if req.id == 3.into() && req.method == "shutdown")
+        );
     }
 
     #[test]
@@ -261,7 +264,9 @@ mod tests {
         let text = "{\"jsonrpc\": \"2.0\",\"id\": 3,\"method\": \"shutdown\"}";
         let msg: Message = serde_json::from_str(&text).unwrap();
 
-        assert!( matches!(msg, Message::Request(req) if req.id == 3.into() && req.method == "shutdown") );
+        assert!(
+            matches!(msg, Message::Request(req) if req.id == 3.into() && req.method == "shutdown")
+        );
     }
 
     #[test]
@@ -269,7 +274,7 @@ mod tests {
         let text = "{\"jsonrpc\": \"2.0\",\"method\": \"exit\", \"params\": null }";
         let msg: Message = serde_json::from_str(&text).unwrap();
 
-        assert!( matches!(msg, Message::Notification(not) if not.method == "exit") );
+        assert!(matches!(msg, Message::Notification(not) if not.method == "exit"));
     }
 
     #[test]
@@ -277,7 +282,6 @@ mod tests {
         let text = "{\"jsonrpc\": \"2.0\",\"method\": \"exit\"}";
         let msg: Message = serde_json::from_str(&text).unwrap();
 
-        assert!( matches!(msg, Message::Notification(not) if not.method == "exit") );
+        assert!(matches!(msg, Message::Notification(not) if not.method == "exit"));
     }
-
 }


### PR DESCRIPTION
As per specification `params` property for [ResponseMessage](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage) and [NotificationMessage ](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage) is optional.  While lsp-server requires that it should be explicitly set to null.

So this request works:
`{"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": null }`

And this one (a perfectly valid request as per my understanding) causes rust-analyzer to panic:
`{"jsonrpc": "2.0", "id": 3, "method": "shutdown" }`

<details><summary>Panic:</summary><pre>
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', C:\Users\vit\.cargo\registry\src\github.com-1ecc6299db9ec823\lsp-server-0.3.3\src\req_queue.rs:60:9
stack backtrace:
   0: backtrace::backtrace::trace_unsynchronized
             at C:\Users\VssAdministrator\.cargo\registry\src\github.com-1ecc6299db9ec823\backtrace-0.3.46\src\backtrace\mod.rs:66
   1: std::sys_common::backtrace::_print_fmt
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\sys_common\backtrace.rs:78
   2: std::sys_common::backtrace::_print::{{impl}}::fmt
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\sys_common\backtrace.rs:59
   3: core::fmt::write
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libcore\fmt\mod.rs:1076
   4: std::io::Write::write_fmt<std::sys::windows::stdio::Stderr>
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\io\mod.rs:1537
   5: std::sys_common::backtrace::_print
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\sys_common\backtrace.rs:62
   6: std::sys_common::backtrace::print
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\sys_common\backtrace.rs:49
   7: std::panicking::default_hook::{{closure}}
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:198
   8: std::panicking::default_hook
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:218
   9: std::panicking::rust_panic_with_hook
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:486
  10: std::panicking::begin_panic_handler
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:388
  11: core::panicking::panic_fmt
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libcore\panicking.rs:101
  12: core::panicking::panic
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libcore\panicking.rs:56
  13: core::option::Option<fn(mut rust_analyzer::global_state::GlobalState*, lsp_server::msg::Response)>::unwrap<fn(mut rust_analyzer::global_state::GlobalState*, lsp_server::msg::Response)>
             at C:\Users\vit\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\src\libcore\macros\mod.rs:10
  14: lsp_server::req_queue::Outgoing<fn(mut rust_analyzer::global_state::GlobalState*, lsp_server::msg::Response)>::complete<fn(mut rust_analyzer::global_state::GlobalState*, lsp_server::msg::Response)>
             at C:\Users\vit\.cargo\registry\src\github.com-1ecc6299db9ec823\lsp-server-0.3.3\src\req_queue.rs:60
  15: rust_analyzer::global_state::GlobalState::complete_request
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\global_state.rs:207
  16: rust_analyzer::global_state::GlobalState::handle_event
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\main_loop.rs:191
  17: rust_analyzer::global_state::GlobalState::run
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\main_loop.rs:151
  18: rust_analyzer::main_loop::main_loop
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\main_loop.rs:50
  19: rust_analyzer::run_server
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\bin\main.rs:139
  20: rust_analyzer::try_main
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\bin\main.rs:41
  21: rust_analyzer::main
             at E:\Projects\Rust\rust-analyzer\crates\rust-analyzer\src\bin\main.rs:31
  22: std::rt::lang_start::{{closure}}<()>
             at C:\Users\vit\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\src\libstd\rt.rs:67
  23: std::rt::lang_start_internal::{{closure}}
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\rt.rs:52
  24: std::panicking::try::do_call
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:297
  25: std::panicking::try
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panicking.rs:274
  26: std::panic::catch_unwind
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\panic.rs:394
  27: std::rt::lang_start_internal
             at /rustc/c367798cfd3817ca6ae908ce675d1d99242af148\/src\libstd\rt.rs:51
  28: std::rt::lang_start<()>
             at C:\Users\vit\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\src\libstd\rt.rs:67
  29: main
  30: invoke_main
             at D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  31: __scrt_common_main_seh
             at D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  32: BaseThreadInitThunk
  33: RtlUserThreadStart
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
</pre></details>


Instead-of `Message::Request` the message deserializes as `Message::Response`

This PR fixes this.