### PR TITLE
3.16 has clarified the range of numbers as being 32bit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "lsp-server"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["rust-analyzer developers"]
 repository = "https://github.com/rust-analyzer/lsp-server"
 license = "MIT OR Apache-2.0"
@@ -17,4 +17,4 @@ serde = { version = "1.0.83", features = ["derive"] }
 crossbeam-channel = "0.5"
 
 [dev-dependencies]
-lsp-types = "0.82.0"
+lsp-types = "0.83.1"

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -38,13 +38,13 @@ pub struct RequestId(IdRepr);
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(untagged)]
 enum IdRepr {
-    U64(u64),
+    I32(i32),
     String(String),
 }
 
-impl From<u64> for RequestId {
-    fn from(id: u64) -> RequestId {
-        RequestId(IdRepr::U64(id))
+impl From<i32> for RequestId {
+    fn from(id: i32) -> RequestId {
+        RequestId(IdRepr::I32(id))
     }
 }
 
@@ -57,7 +57,7 @@ impl From<String> for RequestId {
 impl fmt::Display for RequestId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            IdRepr::U64(it) => fmt::Display::fmt(it, f),
+            IdRepr::I32(it) => fmt::Display::fmt(it, f),
             // Use debug here, to make it clear that `92` and `"92"` are
             // different, and to reduce WTF factor if the sever uses `" "` as an
             // ID.

--- a/src/req_queue.rs
+++ b/src/req_queue.rs
@@ -27,7 +27,7 @@ pub struct Incoming<I> {
 
 #[derive(Debug)]
 pub struct Outgoing<O> {
-    next_id: u64,
+    next_id: i32,
     pending: HashMap<RequestId, O>,
 }
 


### PR DESCRIPTION
See: https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#number