### PR TITLE
Fix panic on invalid request/notification

### DIFF
--- a/examples/goto_def.rs
+++ b/examples/goto_def.rs
@@ -47,7 +47,7 @@ use lsp_types::{
     request::GotoDefinition, GotoDefinitionResponse, InitializeParams, ServerCapabilities,
 };
 
-use lsp_server::{Connection, Message, Request, RequestId, Response};
+use lsp_server::{Connection, Message, Request, RequestError, RequestId, Response};
 
 fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
     // Note that  we must have our logging only write out to stderr.
@@ -106,7 +106,7 @@ fn main_loop(
     Ok(())
 }
 
-fn cast<R>(req: Request) -> Result<(RequestId, R::Params), Request>
+fn cast<R>(req: Request) -> Result<(RequestId, R::Params), RequestError>
 where
     R: lsp_types::request::Request,
     R::Params: serde::de::DeserializeOwned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@ use crossbeam_channel::{Receiver, Sender};
 
 pub use crate::{
     error::ProtocolError,
-    msg::{ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError},
+    msg::{
+        ErrorCode, Message, Notification, NotificationError, Request, RequestError, RequestId,
+        Response, ResponseError,
+    },
     req_queue::{Incoming, Outgoing, ReqQueue},
     stdio::IoThreads,
 };

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn shutdown_with_explicit_null() {
-        let text = "{\"jsonrpc\": \"2.0\",\"id\": 3,\"method\": \"shutdown\", \"params\": null }";
+        let text = r#"{"jsonrpc": "2.0","id": 3,"method": "shutdown", "params": null }"#;
         let msg: Message = serde_json::from_str(&text).unwrap();
 
         assert!(
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn shutdown_with_no_params() {
-        let text = "{\"jsonrpc\": \"2.0\",\"id\": 3,\"method\": \"shutdown\"}";
+        let text = r#"{"jsonrpc": "2.0","id": 3,"method": "shutdown"}"#;
         let msg: Message = serde_json::from_str(&text).unwrap();
 
         assert!(
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn notification_with_explicit_null() {
-        let text = "{\"jsonrpc\": \"2.0\",\"method\": \"exit\", \"params\": null }";
+        let text = r#"{"jsonrpc": "2.0","method": "exit", "params": null }"#;
         let msg: Message = serde_json::from_str(&text).unwrap();
 
         assert!(matches!(msg, Message::Notification(not) if not.method == "exit"));
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn notification_with_no_params() {
-        let text = "{\"jsonrpc\": \"2.0\",\"method\": \"exit\"}";
+        let text = r#"{"jsonrpc": "2.0","method": "exit"}"#;
         let msg: Message = serde_json::from_str(&text).unwrap();
 
         assert!(matches!(msg, Message::Notification(not) if not.method == "exit"));
@@ -300,7 +300,7 @@ mod tests {
         });
         let serialized = serde_json::to_string(&msg).unwrap();
 
-        assert_eq!("{\"id\":3,\"method\":\"shutdown\"}", serialized);
+        assert_eq!(r#"{"id":3,"method":"shutdown"}"#, serialized);
     }
 
     #[test]
@@ -311,6 +311,6 @@ mod tests {
         });
         let serialized = serde_json::to_string(&msg).unwrap();
 
-        assert_eq!("{\"method\":\"exit\"}", serialized);
+        assert_eq!(r#"{"method":"exit"}"#, serialized);
     }
 }


### PR DESCRIPTION
Fixes #23

This PR will hopefully help ensure RA does not panic and crash an invalid request/notification passes through it.

This is a breaking change and RA will have to be modified in consequence. I'm up for it if this is accepted.

I used the same pattern as the existing `ResponseError` type for where to place the new code: just below the original type.

There weren't tests to modify, just the example, which still passes for me, so I'm not sure if there is anything else to do.