### PR TITLE
Potential improvements to error reporting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl Connection {
                     "expected Message::Notification, got: {:?}",
                     msg,
                 )))
-            },
+            }
             Err(e) => {
                 return Err(ProtocolError(format!(
                     "expected initialized notification, got error: {}",
@@ -203,8 +203,12 @@ impl Connection {
         let _ = self.sender.send(resp.into());
         match &self.receiver.recv_timeout(std::time::Duration::from_secs(30)) {
             Ok(Message::Notification(n)) if n.is_exit() => (),
-            Ok(msg) => return Err(ProtocolError(format!("unexpected message during shutdown: {:?}", msg))),
-            Err(e) => return Err(ProtocolError(format!("unexpected error during shutdown: {}", e)))
+            Ok(msg) => {
+                return Err(ProtocolError(format!("unexpected message during shutdown: {:?}", msg)))
+            }
+            Err(e) => {
+                return Err(ProtocolError(format!("unexpected error during shutdown: {}", e)))
+            }
         }
         Ok(true)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,10 +110,16 @@ impl Connection {
                         self.sender.send(resp.into()).unwrap();
                     }
                 }
-                msg => {
+                Ok(msg) => {
                     return Err(ProtocolError(format!(
                         "expected initialize request, got {:?}",
                         msg
+                    )))
+                }
+                Err(e) => {
+                    return Err(ProtocolError(format!(
+                        "expected initialize request, got error: {}",
+                        e
                     )))
                 }
             };
@@ -130,10 +136,16 @@ impl Connection {
         self.sender.send(resp.into()).unwrap();
         match &self.receiver.recv() {
             Ok(Message::Notification(n)) if n.is_initialized() => (),
-            m => {
+            Ok(msg) => {
                 return Err(ProtocolError(format!(
-                    "expected initialized notification, got {:?}",
-                    m
+                    "expected Message::Notification, got: {:?}",
+                    msg,
+                )))
+            },
+            Err(e) => {
+                return Err(ProtocolError(format!(
+                    "expected initialized notification, got error: {}",
+                    e,
                 )))
             }
         }
@@ -191,7 +203,8 @@ impl Connection {
         let _ = self.sender.send(resp.into());
         match &self.receiver.recv_timeout(std::time::Duration::from_secs(30)) {
             Ok(Message::Notification(n)) if n.is_exit() => (),
-            m => return Err(ProtocolError(format!("unexpected message during shutdown: {:?}", m))),
+            Ok(msg) => return Err(ProtocolError(format!("unexpected message during shutdown: {:?}", msg))),
+            Err(e) => return Err(ProtocolError(format!("unexpected error during shutdown: {}", e)))
         }
         Ok(true)
     }


### PR DESCRIPTION
I've started experimenting with LSP (I'm new to using and interacting with language servers) and ran into some difficulties understanding the errors. I tried launching the example with `cargo run --example goto_def` and just copy-pasted some jsonrpc messages and it didn't work out. Here's how an interaction like this might look on master:

``` sh-session
% cargo run --example goto_def  
starting generic LSP server
foo
Error: ProtocolError("expected initialize request, got Err(RecvError)")
```

After doing some digging I can see that the `RecvError` should have some more information, but the way that it's being printed doesn't show me a lot of it. Here's how the same interaction is rendered in this branch:

``` sh-session
% cargo run --example goto_def
starting generic LSP server
foo
Error: ProtocolError("expected initialize request, got error: receiving on an empty and disconnected channel")
```

So now I can at least guess that the problem doesn't have to do with parsing, but with the way the input is sent, and it would have to be the first thing to fix (like piping the commands by using a file).

I think this is an improvement, but there might be different ways to make it better -- let me know. I'd also consider using `unreachable!` in cases where a `Message::Request` is expected, but a `Message::Response` is given, for example.