### PR TITLE
bump to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "lsp-server"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["rust-analyzer developers"]
 repository = "https://github.com/rust-analyzer/lsp-server"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- bumps to `0.5.2`
- follow-on from https://github.com/rust-analyzer/lsp-server/pull/34#issuecomment-869613429