### PR TITLE
Example does not shutdown gracefully

### DIFF
--- a/examples/goto_def.rs
+++ b/examples/goto_def.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
     // Run the server and wait for the two threads to end (typically by trigger LSP Exit event).
     let server_capabilities = serde_json::to_value(&ServerCapabilities::default()).unwrap();
     let initialization_params = connection.initialize(server_capabilities)?;
-    main_loop(&connection, initialization_params)?;
+    main_loop(connection, initialization_params)?;
     io_threads.join()?;
 
     // Shut down gracefully.
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
 }
 
 fn main_loop(
-    connection: &Connection,
+    connection: Connection,
     params: serde_json::Value,
 ) -> Result<(), Box<dyn Error + Sync + Send>> {
     let _params: InitializeParams = serde_json::from_value(params).unwrap();


### PR DESCRIPTION
The goto definition example doesn't shutdown gracefully. This is because the connection is borrowed by the main_loop function instead of moved into it.

The client sends a shutdown request to the server. The server replies with a response with the same id. Then the client sends an exit notification. The input thread of IoThreads will exit here, but the output thread stays alive.

By moving the connection into the main_loop function (instead of borrowing) the connection will be dropped at the end of main_loop function. This will also drop the sender side of the output channel. Then the output thread will also exit because the receiver side will no longer receive any messages.

Now the io_threads.join() will actually finish instead of "deadlock" on waiting for output messages that will no longer be created by the server.

In rust-analyzer the connection is also moved instead of borrowed by the main_loop function:
https://github.com/rust-analyzer/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/crates/rust-analyzer/src/bin/main.rs#L181
