### PR TITLE
Add note to readme explaining that the crate source has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
         src="https://img.shields.io/librariesio/release/cargo/lsp-server.svg?logo=rust" /></a>
   </p>
   <strong>A language server scaffold exposing a crossbeam-channel API.</strong>
+  <h2>This crate has been vendored into the <a href="https://github.com/rust-lang/rust-analyzer/tree/master/lib/lsp-server">rust-analyzer repo</a></h2>
 </div>
 
 ## Description


### PR DESCRIPTION
We might also wanna archive the repo, the source of the crate now lives in r-a https://github.com/rust-lang/rust-analyzer/pull/12251